### PR TITLE
Macosx build support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,11 @@ AM_CONDITIONAL([ENABLE_UNZOO], [test "x$enable_unzoo" != "xno"])
 
 AC_CANONICAL_HOST
 case $host in
-  *-linux*)
+  *-linux* | *-apple*)
     MACHINE=-DLINUX
     SYS=-DSYS_IS_UNIX
     ;;
-  *-freebsd* | *-openbsd* | *-netbsd* | *-dragonfly* | *-solaris* | *-apple*)
+  *-freebsd* | *-openbsd* | *-netbsd* | *-dragonfly* | *-solaris*)
     MACHINE=-DBSD4_3
     SYS=-DSYS_IS_UNIX
     ;;

--- a/src/zooadd.c
+++ b/src/zooadd.c
@@ -10,6 +10,7 @@
 #ifdef HAVE_NFTW
 #define _XOPEN_SOURCE 500	/* Rrequired on GLIBC */
 #define _GNU_SOURCE		/* -- " -- " -- " --  */
+#define _POSIX_C_SOURCE 200809L	/* -- " -- " -- " --  */
 #include <ftw.h>
 #endif
 


### PR DESCRIPTION
I added a couple of niceties in order to build successfully on a "more modern" OSX  (14.7 (23H124) in my case)

* Update configure.ac

Update system guesses to be more like Linux than BSD; works better for "more modern" OSX

* Update for OSX compile issues

Defining _POSIX_C_SOURCE to a value equal or greater than 200809L allows us to re-acquire non-standard library functions (strdup() in our case is a posix extension) that strict ANSI checking hides.